### PR TITLE
Emit stop error event on client and server timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cowboy:start_clear(http, [{port, Port}], #{
 A span event emitted at the beginning of a request.
 
 * `measurements`: `#{system_time => erlang:system_time()}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), req => cowboy_req:req(), request_process => pid()}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), req => cowboy_req:req()}`
 
 #### `[cowboy, request, stop]`
 
@@ -68,4 +68,4 @@ Additional types for reference:
 
 Note:
 
-* The `telemetry` handlers will be executed from the cowboy connection process, not from the request process. The `start` event will contain the pid of the `request_process`.
+* The `telemetry` handlers are executed from the cowboy connection process, not from the request process.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A span event emitted at the beginning of a request.
 A span event emitted at the end of a request.
 
 * `measurements`: `#{duration => native_time}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), response => response()}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), response => cowboy_stream:resp_command()}`
 
 If the request is terminated by the client before a response is sent, the metadata contains an `error` instead of a `response`,
 
@@ -56,7 +56,6 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
 Additional types for reference:
 
 ```erlang
-- type response() :: {response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
 - type error_response() :: {error_response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
-- type error() :: {socket_error, atom(), human_reason()}
+- type error() :: {socket_error, atom(), cowboy_stream:human_reason()}
 ```

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ A span event emitted at the end of a request.
 * `measurements`: `#{duration => native_time}`
 * `metadata`: `#{stream_id => cowboy_stream:streamid(), response => cowboy_stream:resp_command()}`
 
-If the request is terminated by the client before a response is sent, the metadata contains an `error` instead of a `response`,
+If the request is terminated early - by the client or by the server - before a response is sent, the metadata contains an `error` instead of a `response`,
 
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), error => error()}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), error => early_termination_error()}`
 
 #### `[cowboy, request, exception]`
 
@@ -57,5 +57,7 @@ Additional types for reference:
 
 ```erlang
 - type error_response() :: {error_response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
-- type error() :: {socket_error, atom(), cowboy_stream:human_reason()}
+
+- type early_termination_error() :: {socket_error, closed | atom(), cowboy_stream:human_reason()}
+                                    | {connection_error, timeout, cowboy_stream:human_reason()}.
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cowboy:start_clear(http, [{port, Port}], #{
 A span event emitted at the beginning of a request.
 
 * `measurements`: `#{system_time => erlang:system_time()}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), req => cowboy_req:req()}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), req => cowboy_req:req(), request_process => pid()}`
 
 #### `[cowboy, request, stop]`
 
@@ -35,7 +35,7 @@ A span event emitted at the end of a request.
 * `measurements`: `#{duration => native_time}`
 * `metadata`: `#{stream_id => cowboy_stream:streamid(), response => response()}`
 
-If the request is streamed in chunks, the resp_body reported will be `nil`.
+If the request is streamed in chunks, the `resp_body` reported will be `nil`.
 
 If the request is terminated early - by the client or by the server - before a response is sent, the metadata contains an `error` instead of a `response`,
 
@@ -65,3 +65,7 @@ Additional types for reference:
 - type early_termination_error() :: {socket_error, closed | atom(), cowboy_stream:human_reason()}
                                     | {connection_error, timeout, cowboy_stream:human_reason()}.
 ```
+
+Note:
+
+* The `telemetry` handlers will be executed from the cowboy connection process, not from the request process. The `start` event will contain the pid of the `request_process`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ A span event emitted at the beginning of a request.
 A span event emitted at the end of a request.
 
 * `measurements`: `#{duration => native_time}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), response => cowboy_stream:resp_command()}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), response => response()}`
+
+If the request is streamed in chunks, the resp_body reported will be `nil`.
 
 If the request is terminated early - by the client or by the server - before a response is sent, the metadata contains an `error` instead of a `response`,
 
@@ -56,6 +58,8 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
 Additional types for reference:
 
 ```erlang
+- type response() :: {response, cowboy:http_status(), cowboy:http_headers(), nil | cowboy_req:resp_body()}.
+
 - type error_response() :: {error_response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
 
 - type early_termination_error() :: {socket_error, closed | atom(), cowboy_stream:human_reason()}

--- a/README.md
+++ b/README.md
@@ -21,29 +21,42 @@ cowboy:start_clear(http, [{port, Port}], #{
 
 ## Telemetry Events
 
-Span events emitted:
+#### `[cowboy, request, start]`
 
-* `[cowboy, request, start]`
-  * `measurements`: `#{system_time => erlang:system_time()}`
-  * `metadata`: `#{stream_id => cowboy_stream:streamid(), req => cowboy_req:req()}`
+A span event emitted at the beginning of a request.
 
-* `[cowboy, request, stop]`
-  * `measurements`: `#{duration => native_time}`
-  * `metadata`: `#{stream_id => cowboy_stream:streamid(), response => response()}`
+* `measurements`: `#{system_time => erlang:system_time()}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), req => cowboy_req:req()}`
 
-* `[cowboy, request, exception]`
-  * `measurements`: `#{duration => native_time}`
-  * `metadata`: `#{stream_id => cowboy_stream:streamid(), kind => exit, reason => any(), response => error_response()}`
+#### `[cowboy, request, stop]`
 
-A single event is emitted when `cowboy` returns an `early_error` response:
+A span event emitted at the end of a request.
 
-* `[cowboy, request, early_error]`
-  * `measurements`: `#{duration => native_time}`
-  * `metadata`: `#{stream_id => cowboy_stream:streamid(), reason => cowboy_stream:reason(), partial_req => cowboy_stream:partial_req()}`
+* `measurements`: `#{duration => native_time}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), response => response()}`
+
+If the request is terminated by the client before a response is sent, the metadata contains an `error` instead of a `response`,
+
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), error => error()}`
+
+#### `[cowboy, request, exception]`
+
+A span event emitted if the request process exits.
+
+* `measurements`: `#{duration => native_time}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), kind => exit, reason => any(), response => error_response()}`
+
+#### `[cowboy, request, early_error]`
+
+A single event emitted when Cowboy itself returns an `early_error` response before executing any handlers.
+
+* `measurements`: `#{duration => native_time}`
+* `metadata`: `#{stream_id => cowboy_stream:streamid(), reason => cowboy_stream:reason(), partial_req => cowboy_stream:partial_req()}`
 
 Additional types for reference:
 
 ```erlang
 - type response() :: {response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
 - type error_response() :: {error_response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
+- type error() :: {socket_error, atom(), human_reason()}
 ```

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -7,104 +7,99 @@
 -export([terminate/3]).
 -export([early_error/5]).
 
+% Request Flows:
+%
+% There are multiple ways a request flows through the stream handler callbacks.
+% All start with `init`, where we emit our span start event. In each flow, the location
+% where we emit the span stop event is designated with ^^. All events are based on the
+% Commands returned by cowboy.
+%
+% successful_request     == init -> info(response) ^^ -> info(stop) -> terminate(normal)
+% failed_request         == init -> info(error_response) ^^ -> terminate(internal_error)
+% chunked_request        == init -> info(headers) -> info(data|nofin) -> info(data|fin) ^^ -> info(stop) -> terminate(normal)
+% client_timeout_request == init -> terminate(socket_error) ^^
+% idle_timeout_request   == init -> terminate(connection_error) ^^
+% chunk_timeout_request  == init -> info(headers) -> info(data|nofin) -> terminate(connection_error) ^^
+% bad_request            == early_error
+
 -record(state, {
     next :: any(),
 
+    % Request identity
     streamid :: cowboy_stream:streamid(),
-    connection_process :: pid(),
     request_process :: pid(),
 
+    % Response info
     start_time :: integer(),
-
-    emit :: undefined | stop | exception | done,
-
     response :: undefined | {response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()},
     error_response :: undefined | {error_response, cowboy:http_status(), cowboy:http_headers(), iodata()},
-    reason :: undefined | any()
+    reason :: undefined | any(),
+
+    % Span stop tracking
+    emit :: undefined | stop | exception | done
 }).
 
 init(StreamID, Req, Opts) ->
-    StartTime = emit_start_event(StreamID, Req),
+    StartTime = erlang:monotonic_time(),
+    SystemTime = erlang:system_time(),
     {Commands, Next} = cowboy_stream:init(StreamID, Req, Opts),
-    % io:format("~ninit ~p~n~p~n", [Commands, Req]),
-    {Commands, fold(Commands, #state{
-        next=Next,
-        streamid=StreamID,
-        connection_process=self(),
-        start_time=StartTime
-    })}.
+    State = fold(Commands, #state{next=Next, streamid=StreamID, start_time=StartTime}),
+    span_start(State, SystemTime, Req),
+    {Commands, State}.
+
 
 data(StreamID, IsFin, Data, State=#state{next=Next0}) ->
     {Commands, Next} = cowboy_stream:data(StreamID, IsFin, Data, Next0),
-    io:format("~ndata ~p~n", [Commands]),
     {Commands, State#state{next=Next}}.
 
-% Request Flows:
-%
-% init -> response^^ -> stop -> terminate(normal)         == successful_request
-% init -> error_response^^ -> terminate(internal_error)   == failed_request
-% init -> terminate^^(connection_error)                   == idle_timeout_request
-% init -> terminate^^(socket_error)                        == client_timeout_request
-% init -> headers -> data -> datap^^(fin) -> stop -> terminate(normal)  == stream_request
-%
-% early_error
 
-info(StreamID, Info, State=#state{next=Next0}) ->
+info(StreamID, Info, State0=#state{next=Next0}) ->
     {Commands, Next} = cowboy_stream:info(StreamID, Info, Next0),
-    io:format("~ninfo ~p~n", [Commands]),
-    State1 = fold(Commands, State#state{next=Next}),
-    emit_at_end(State1),
+    State1 = fold(Commands, State0#state{next=Next}),
+    span_stop(State1),
     {Commands, State1}.
 
 
 terminate(StreamID, Reason, #state{emit=done, next=Next}) ->
-    io:format("~nterminate(done) ~p~n", [Reason]),
     cowboy_stream:terminate(StreamID, Reason, Next);
 
-terminate(StreamID, {socket_error, _, _} = Reason, #state{next=Next} = State) ->
-    io:format("~nterminate^^(socket_error) ~p~n", [Reason]),
-    emit_at_end(State#state{emit=error, reason=Reason}),
-    cowboy_stream:terminate(StreamID, Reason, Next);
-
-terminate(StreamID, {connection_error, _, _} = Reason, #state{next=Next} = State) ->
-    io:format("~nterminate^^(connection_error) ~p~n", [Reason]),
-    emit_at_end(State#state{emit=error, reason=Reason}),
+terminate(StreamID, {ErrorType, _, _} = Reason, #state{next=Next} = State)
+    when ErrorType == socket_error; ErrorType == connection_error ->
+    span_stop(State#state{emit=error, reason=Reason}),
     cowboy_stream:terminate(StreamID, Reason, Next);
 
 terminate(StreamID, Reason, #state{next=Next}) ->
-    io:format("~nterminate ~p~n", [Reason]),
     cowboy_stream:terminate(StreamID, Reason, Next).
 
 
 early_error(StreamID, Reason, PartialReq, Resp0, Opts) ->
-    io:format("~nearly_error ~p~n", [Reason]),
     Resp = cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp0, Opts),
     emit_early_error_event(StreamID, Reason, PartialReq, Resp),
     Resp.
 
-% fold over Commands
+%
 
 fold([], State) ->
     State;
 
 fold([{response, _, _, _} = Response | Tail], State0) ->
-    State = State0#state{response=Response, emit=stop},
-    fold(Tail, State);
-
-fold([{headers, RespStatus, RespHeaders} | Tail], State0) ->
-    State = State0#state{response={response, RespStatus, RespHeaders, nil}},
+    State = State0#state{emit=stop, response=Response},
     fold(Tail, State);
 
 fold([{data, fin, _} | Tail], State0) ->
     State = State0#state{emit=stop},
     fold(Tail, State);
 
-fold([{error_response, _, _, _} = ErrorResponse | Tail], State0) ->
-    State = State0#state{error_response=ErrorResponse},
+fold([{internal_error, {'EXIT', _, Reason}, _} | Tail], State0) ->
+    State = State0#state{emit=exception, reason=Reason},
     fold(Tail, State);
 
-fold([{internal_error, {'EXIT', _, Reason}, _} | Tail], State0) ->
-    State = State0#state{reason=Reason, emit=exception},
+fold([{headers, RespStatus, RespHeaders} | Tail], State0) ->
+    State = State0#state{response={response, RespStatus, RespHeaders, nil}},
+    fold(Tail, State);
+
+fold([{error_response, _, _, _} = ErrorResponse | Tail], State0) ->
+    State = State0#state{error_response=ErrorResponse},
     fold(Tail, State);
 
 fold([{spawn, Pid, _} | Tail], State0) ->
@@ -114,34 +109,33 @@ fold([{spawn, Pid, _} | Tail], State0) ->
 fold([_ | Tail], State) ->
     fold(Tail, State).
 
-% Emit when signaled
 
-emit_at_end(#state{emit=stop, streamid=StreamID, start_time=StartTime, response=Response} = State) ->
+span_start(#state{streamid=StreamID, request_process=RequestProcess}, SystemTime, Req) ->
+    emit_start_event(StreamID, SystemTime, Req, RequestProcess).
+
+
+span_stop(#state{emit=stop, streamid=StreamID, start_time=StartTime, response=Response} = State) ->
     emit_stop_event(StreamID, StartTime, Response),
     State#state{emit=done};
 
-emit_at_end(#state{emit=error, streamid=StreamID, start_time=StartTime, reason=Reason} = State) ->
+span_stop(#state{emit=error, streamid=StreamID, start_time=StartTime, reason=Reason} = State) ->
     emit_stop_error_event(StreamID, StartTime, Reason),
     State#state{emit=done};
 
-emit_at_end(#state{emit=exception, streamid=StreamID, start_time=StartTime, error_response=ErrorResponse, reason=Reason} = State) ->
+span_stop(#state{emit=exception, streamid=StreamID, start_time=StartTime, error_response=ErrorResponse, reason=Reason} = State) ->
     emit_exception_event(StreamID, StartTime, Reason, ErrorResponse),
     State#state{emit=done};
 
-emit_at_end(State) ->
+span_stop(State) ->
     State.
 
-% Telemetry events
 
-emit_start_event(StreamID, Req) ->
-    SystemTime = erlang:system_time(),
-    StartTime = erlang:monotonic_time(),
+emit_start_event(StreamID, SystemTime, Req, RequestProcess) ->
     telemetry:execute(
         [cowboy, request, start],
         #{system_time => SystemTime},
-        #{stream_id => StreamID, req => Req}
-    ),
-    StartTime.
+        #{stream_id => StreamID, req => Req, request_process => RequestProcess}
+    ).
 
 emit_stop_event(StreamID, StartTime, Response) ->
     EndTime = erlang:monotonic_time(),
@@ -153,7 +147,6 @@ emit_stop_event(StreamID, StartTime, Response) ->
 
 emit_stop_error_event(StreamID, StartTime, Reason) ->
     EndTime = erlang:monotonic_time(),
-    io:format("~p~n", [Reason]),
     telemetry:execute(
         [cowboy, request, stop],
         #{duration => EndTime - StartTime},

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -9,55 +9,127 @@
 
 -record(state, {
     next :: any(),
-    status :: undefined | active,
-    start_time :: integer()
+
+    streamid :: cowboy_stream:streamid(),
+    connection_process :: pid(),
+    request_process :: pid(),
+
+    start_time :: integer(),
+
+    emit :: undefined | stop | exception | done,
+
+    response :: undefined | {response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()},
+    error_response :: undefined | {error_response, cowboy:http_status(), cowboy:http_headers(), iodata()},
+    reason :: undefined | any()
 }).
 
 init(StreamID, Req, Opts) ->
     StartTime = emit_start_event(StreamID, Req),
     {Commands, Next} = cowboy_stream:init(StreamID, Req, Opts),
-    {Commands, #state{next=Next, start_time=StartTime}}.
+    % io:format("~ninit ~p~n~p~n", [Commands, Req]),
+    {Commands, fold(Commands, #state{
+        next=Next,
+        streamid=StreamID,
+        connection_process=self(),
+        start_time=StartTime
+    })}.
 
 data(StreamID, IsFin, Data, State=#state{next=Next0}) ->
     {Commands, Next} = cowboy_stream:data(StreamID, IsFin, Data, Next0),
+    io:format("~ndata ~p~n", [Commands]),
     {Commands, State#state{next=Next}}.
 
-info(StreamID, Info, State=#state{next=Next0, start_time=StartTime}) ->
-    {Commands, Next} = cowboy_stream:info(StreamID, Info, Next0),
-    Status =
-        case Commands of
-            [{response, _, _, _} = Response] ->
-                emit_stop_event(StreamID, StartTime, Response),
-                done;
-            [{error_response, _, _, _} = ErrorResponse | Commands1] ->
-                case lists:keyfind(internal_error, 1, Commands1) of
-                    {internal_error, {'EXIT', _, Reason}, _} ->
-                        emit_exception_event(StreamID, StartTime, Reason, ErrorResponse),
-                        done;
-                    _ ->
-                        undefined
-                end;
-            _ ->
-                undefined
-        end,
-    {Commands, State#state{next=Next, status=Status}}.
+% Request Flows:
+%
+% init -> response^^ -> stop -> terminate(normal)         == successful_request
+% init -> error_response^^ -> terminate(internal_error)   == failed_request
+% init -> terminate^^(connection_error)                   == idle_timeout_request
+% init -> terminate^^(socket_error)                        == client_timeout_request
+% init -> headers -> data -> datap^^(fin) -> stop -> terminate(normal)  == stream_request
+%
+% early_error
 
-terminate(StreamID, Reason, #state{status=done, next=Next}) ->
+info(StreamID, Info, State=#state{next=Next0}) ->
+    {Commands, Next} = cowboy_stream:info(StreamID, Info, Next0),
+    io:format("~ninfo ~p~n", [Commands]),
+    State1 = fold(Commands, State#state{next=Next}),
+    emit_at_end(State1),
+    {Commands, State1}.
+
+
+terminate(StreamID, Reason, #state{emit=done, next=Next}) ->
+    io:format("~nterminate(done) ~p~n", [Reason]),
     cowboy_stream:terminate(StreamID, Reason, Next);
-terminate(StreamID, Reason, #state{next=Next, start_time=StartTime}) ->
-    case Reason of
-        {socket_error, _, _} = Reason ->
-            emit_stop_error_event(StreamID, StartTime, Reason);
-        {connection_error, _, _} = Reason ->
-            emit_stop_error_event(StreamID, StartTime, Reason);
-        _ -> ignore
-    end,
+
+terminate(StreamID, {socket_error, _, _} = Reason, #state{next=Next} = State) ->
+    io:format("~nterminate^^(socket_error) ~p~n", [Reason]),
+    emit_at_end(State#state{emit=error, reason=Reason}),
+    cowboy_stream:terminate(StreamID, Reason, Next);
+
+terminate(StreamID, {connection_error, _, _} = Reason, #state{next=Next} = State) ->
+    io:format("~nterminate^^(connection_error) ~p~n", [Reason]),
+    emit_at_end(State#state{emit=error, reason=Reason}),
+    cowboy_stream:terminate(StreamID, Reason, Next);
+
+terminate(StreamID, Reason, #state{next=Next}) ->
+    io:format("~nterminate ~p~n", [Reason]),
     cowboy_stream:terminate(StreamID, Reason, Next).
 
+
 early_error(StreamID, Reason, PartialReq, Resp0, Opts) ->
+    io:format("~nearly_error ~p~n", [Reason]),
     Resp = cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp0, Opts),
     emit_early_error_event(StreamID, Reason, PartialReq, Resp),
     Resp.
+
+% fold over Commands
+
+fold([], State) ->
+    State;
+
+fold([{response, _, _, _} = Response | Tail], State0) ->
+    State = State0#state{response=Response, emit=stop},
+    fold(Tail, State);
+
+fold([{headers, RespStatus, RespHeaders} | Tail], State0) ->
+    State = State0#state{response={response, RespStatus, RespHeaders, nil}},
+    fold(Tail, State);
+
+fold([{data, fin, _} | Tail], State0) ->
+    State = State0#state{emit=stop},
+    fold(Tail, State);
+
+fold([{error_response, _, _, _} = ErrorResponse | Tail], State0) ->
+    State = State0#state{error_response=ErrorResponse},
+    fold(Tail, State);
+
+fold([{internal_error, {'EXIT', _, Reason}, _} | Tail], State0) ->
+    State = State0#state{reason=Reason, emit=exception},
+    fold(Tail, State);
+
+fold([{spawn, Pid, _} | Tail], State0) ->
+    State = State0#state{request_process=Pid},
+    fold(Tail, State);
+
+fold([_ | Tail], State) ->
+    fold(Tail, State).
+
+% Emit when signaled
+
+emit_at_end(#state{emit=stop, streamid=StreamID, start_time=StartTime, response=Response} = State) ->
+    emit_stop_event(StreamID, StartTime, Response),
+    State#state{emit=done};
+
+emit_at_end(#state{emit=error, streamid=StreamID, start_time=StartTime, reason=Reason} = State) ->
+    emit_stop_error_event(StreamID, StartTime, Reason),
+    State#state{emit=done};
+
+emit_at_end(#state{emit=exception, streamid=StreamID, start_time=StartTime, error_response=ErrorResponse, reason=Reason} = State) ->
+    emit_exception_event(StreamID, StartTime, Reason, ErrorResponse),
+    State#state{emit=done};
+
+emit_at_end(State) ->
+    State.
 
 % Telemetry events
 
@@ -95,7 +167,6 @@ emit_exception_event(StreamID, StartTime, Reason, ErrorResponse) ->
         #{duration => EndTime - StartTime},
         #{stream_id => StreamID, kind => exit, reason => Reason, error_response => ErrorResponse}
     ).
-
 
 emit_early_error_event(StreamID, Reason, PartialReq, Resp) ->
     SystemTime = erlang:system_time(),

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -24,31 +24,36 @@ data(StreamID, IsFin, Data, [Next0 | StartTime]) ->
 
 info(StreamID, Info, [Next0 | StartTime]) ->
     {Commands, Next} = cowboy_stream:info(StreamID, Info, Next0),
-    case Commands of
-        [{response, _, _, _} = Response] ->
-            EndTime = erlang:monotonic_time(),
-            telemetry:execute(
-                [cowboy, request, stop],
-                #{duration => EndTime - StartTime},
-                #{stream_id => StreamID, response => Response}
-            );
-        [{error_response, _, _, _} = ErrorResponse | Commands1] ->
-            EndTime = erlang:monotonic_time(),
-            case lists:keyfind(internal_error, 1, Commands1) of
-                {internal_error, {'EXIT', _, Reason}, _} ->
-                    telemetry:execute(
-                        [cowboy, request, exception],
-                        #{duration => EndTime - StartTime},
-                        #{stream_id => StreamID, kind => exit, reason => Reason, error_response => ErrorResponse}
-                    );
-                _ ->
-                    ignore
-            end;
-        _ ->
-            ignore
-    end,
-    {Commands, [Next | StartTime]}.
+    State =
+        case Commands of
+            [{response, _, _, _} = Response] ->
+                EndTime = erlang:monotonic_time(),
+                telemetry:execute(
+                    [cowboy, request, stop],
+                    #{duration => EndTime - StartTime},
+                    #{stream_id => StreamID, response => Response}
+                ),
+                done;
+            [{error_response, _, _, _} = ErrorResponse | Commands1] ->
+                EndTime = erlang:monotonic_time(),
+                case lists:keyfind(internal_error, 1, Commands1) of
+                    {internal_error, {'EXIT', _, Reason}, _} ->
+                        telemetry:execute(
+                            [cowboy, request, exception],
+                            #{duration => EndTime - StartTime},
+                            #{stream_id => StreamID, kind => exit, reason => Reason, error_response => ErrorResponse}
+                        ),
+                        done;
+                    _ ->
+                        StartTime
+                end;
+            _ ->
+                StartTime
+        end,
+    {Commands, [Next | State]}.
 
+terminate(StreamID, Reason, [Next | done]) ->
+    cowboy_stream:terminate(StreamID, Reason, Next);
 terminate(StreamID, Reason, [Next | StartTime]) ->
     case Reason of
         {socket_error, _, _} = Reason ->

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -8,13 +8,7 @@
 -export([early_error/5]).
 
 init(StreamID, Req, Opts) ->
-    SystemTime = erlang:system_time(),
-    StartTime = erlang:monotonic_time(),
-    telemetry:execute(
-        [cowboy, request, start],
-        #{system_time => SystemTime},
-        #{stream_id => StreamID, req => Req}
-    ),
+    StartTime = emit_start_event(StreamID, Req),
     {Commands, Next} = cowboy_stream:init(StreamID, Req, Opts),
     {Commands, [Next | StartTime]}.
 
@@ -27,22 +21,12 @@ info(StreamID, Info, [Next0 | StartTime]) ->
     State =
         case Commands of
             [{response, _, _, _} = Response] ->
-                EndTime = erlang:monotonic_time(),
-                telemetry:execute(
-                    [cowboy, request, stop],
-                    #{duration => EndTime - StartTime},
-                    #{stream_id => StreamID, response => Response}
-                ),
+                emit_stop_event(StreamID, StartTime, Response),
                 done;
             [{error_response, _, _, _} = ErrorResponse | Commands1] ->
-                EndTime = erlang:monotonic_time(),
                 case lists:keyfind(internal_error, 1, Commands1) of
                     {internal_error, {'EXIT', _, Reason}, _} ->
-                        telemetry:execute(
-                            [cowboy, request, exception],
-                            #{duration => EndTime - StartTime},
-                            #{stream_id => StreamID, kind => exit, reason => Reason, error_response => ErrorResponse}
-                        ),
+                        emit_exception_event(StreamID, StartTime, Reason, ErrorResponse),
                         done;
                     _ ->
                         StartTime
@@ -57,27 +41,60 @@ terminate(StreamID, Reason, [Next | done]) ->
 terminate(StreamID, Reason, [Next | StartTime]) ->
     case Reason of
         {socket_error, _, _} = Reason ->
-            emit_early_terminate_error_event(StreamID, StartTime, Reason);
+            emit_stop_error_event(StreamID, StartTime, Reason);
         {connection_error, _, _} = Reason ->
-            emit_early_terminate_error_event(StreamID, StartTime, Reason);
+            emit_stop_error_event(StreamID, StartTime, Reason);
         _ -> ignore
     end,
     cowboy_stream:terminate(StreamID, Reason, Next).
 
 early_error(StreamID, Reason, PartialReq, Resp0, Opts) ->
-    SystemTime = erlang:system_time(),
     Resp = cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp0, Opts),
-    telemetry:execute(
-        [cowboy, request, early_error],
-        #{system_time => SystemTime},
-        #{stream_id => StreamID, reason => Reason, partial_req => PartialReq, response => Resp}
-    ),
+    emit_early_error_event(StreamID, Reason, PartialReq, Resp),
     Resp.
 
-emit_early_terminate_error_event(StreamID, StartTime, Reason) ->
+% Telemetry events
+
+emit_start_event(StreamID, Req) ->
+    SystemTime = erlang:system_time(),
+    StartTime = erlang:monotonic_time(),
+    telemetry:execute(
+        [cowboy, request, start],
+        #{system_time => SystemTime},
+        #{stream_id => StreamID, req => Req}
+    ),
+    StartTime.
+
+emit_stop_event(StreamID, StartTime, Response) ->
     EndTime = erlang:monotonic_time(),
     telemetry:execute(
         [cowboy, request, stop],
         #{duration => EndTime - StartTime},
+        #{stream_id => StreamID, response => Response}
+    ).
+
+emit_stop_error_event(StreamID, StartTime, Reason) ->
+    EndTime = erlang:monotonic_time(),
+    io:format("~p~n", [Reason]),
+    telemetry:execute(
+        [cowboy, request, stop],
+        #{duration => EndTime - StartTime},
         #{stream_id => StreamID, error => Reason}
+    ).
+
+emit_exception_event(StreamID, StartTime, Reason, ErrorResponse) ->
+    EndTime = erlang:monotonic_time(),
+    telemetry:execute(
+        [cowboy, request, exception],
+        #{duration => EndTime - StartTime},
+        #{stream_id => StreamID, kind => exit, reason => Reason, error_response => ErrorResponse}
+    ).
+
+
+emit_early_error_event(StreamID, Reason, PartialReq, Resp) ->
+    SystemTime = erlang:system_time(),
+    telemetry:execute(
+        [cowboy, request, early_error],
+        #{system_time => SystemTime},
+        #{stream_id => StreamID, reason => Reason, partial_req => PartialReq, response => Resp}
     ).

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -51,7 +51,7 @@ successful_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, request_process, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(successful_request_start_event)
     end,
@@ -81,7 +81,7 @@ chunked_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, request_process, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(chunked_request_start_event)
     end,
@@ -111,7 +111,7 @@ failed_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, request_process, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(failed_request_start_event)
     end,
@@ -141,7 +141,7 @@ client_timeout_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, request_process, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(client_timeout_request_start_event)
     end,
@@ -171,7 +171,7 @@ idle_timeout_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, request_process, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(idle_timeout_request_start_event)
     end,
@@ -200,7 +200,7 @@ chunk_timeout_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, request_process, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(chunk_timeout_request_start_event)
     end,

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -7,13 +7,14 @@
 -include_lib("stdlib/include/assert.hrl").
 
 all() ->
-    [successful_request, failed_request, early_error_request].
+    [successful_request, failed_request, client_timeout_request, early_error_request].
 
 init_per_suite(Config) ->
     application:ensure_all_started(ranch),
     application:ensure_all_started(telemetry),
     Dispatch = cowboy_router:compile([{"localhost", [
                                       {"/success", test_h, success},
+                                      {"/slow", test_h, slow},
                                       {"/failure", test_h, failure}
                                      ]}]),
     {ok, _} = cowboy:start_clear(http, [{port, 8080}], #{
@@ -52,7 +53,7 @@ successful_request(_Config) ->
     end,
     receive
         {[cowboy, request, exception], _, _} ->
-            ct:fail(failed_request_unexpected_exception_event)
+            ct:fail(successful_request_unexpected_exception_event)
     after
         100 -> ok
     end.
@@ -83,6 +84,36 @@ failed_request(_Config) ->
     receive
         {[cowboy, request, stop], _, _} ->
             ct:fail(failed_request_unexpected_stop_event)
+    after
+        100 -> ok
+    end.
+
+client_timeout_request(_Config) ->
+    Events = [
+        [cowboy, request, start],
+        [cowboy, request, stop],
+        [cowboy, request, exception]
+    ],
+    telemetry:attach_many(client_timeout_request, Events, fun ?MODULE:echo_event/4, self()),
+    {error, timeout} =
+        httpc:request(get, {"http://localhost:8080/slow", []}, [{timeout, 50}], []),
+    receive
+        {[cowboy, request, start], StartMeasurements, StartMetadata} ->
+            ?assertEqual([system_time], maps:keys(StartMeasurements)),
+            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+    after
+        1000 -> ct:fail(client_timeout_request_start_event)
+    end,
+    receive
+        {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
+            ?assertEqual([duration], maps:keys(StopMeasurements)),
+            ?assertEqual([error, stream_id], maps:keys(StopMetadata))
+    after
+        1000 -> ct:fail(client_timeout_request_stop_event)
+    end,
+    receive
+        {[cowboy, request, exception], _, _} ->
+            ct:fail(client_timeout_request_unexpected_exception_event)
     after
         100 -> ok
     end.

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -196,8 +196,7 @@ chunk_timeout_request(_Config) ->
         [cowboy, request, exception]
     ],
     telemetry:attach_many(chunk_timeout_request, Events, fun ?MODULE:echo_event/4, self()),
-    {ok, {{_Version, 200, _ReasonPhrase}, _Headers, _Body}} =
-        httpc:request(head, {"http://localhost:8080/chunked_slow", []}, [], []),
+    httpc:request(head, {"http://localhost:8080/chunked_slow", []}, [], []),
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),

--- a/test/test_h.erl
+++ b/test/test_h.erl
@@ -5,5 +5,8 @@
 
 init(_, failure) ->
     error(failure);
+init(Req, slow = Opts) ->
+    timer:sleep(100),
+    {ok, cowboy_req:reply(200, #{}, <<"I'm slow">>, Req), Opts};
 init(Req, success = Opts) ->
     {ok, cowboy_req:reply(200, #{}, <<"Hello world!">>, Req), Opts}.

--- a/test/test_h.erl
+++ b/test/test_h.erl
@@ -5,8 +5,11 @@
 
 init(_, failure) ->
     error(failure);
+init(Req, success = Opts) ->
+    {ok, cowboy_req:reply(200, #{}, <<"Hello world!">>, Req), Opts};
 init(Req, slow = Opts) ->
     timer:sleep(100),
     {ok, cowboy_req:reply(200, #{}, <<"I'm slow">>, Req), Opts};
-init(Req, success = Opts) ->
-    {ok, cowboy_req:reply(200, #{}, <<"Hello world!">>, Req), Opts}.
+init(Req, extra_slow = Opts) ->
+    timer:sleep(200),
+    {ok, cowboy_req:reply(200, #{}, <<"I'm extra_slow">>, Req), Opts}.

--- a/test/test_h.erl
+++ b/test/test_h.erl
@@ -8,8 +8,16 @@ init(_, failure) ->
 init(Req, success = Opts) ->
     {ok, cowboy_req:reply(200, #{}, <<"Hello world!">>, Req), Opts};
 init(Req, slow = Opts) ->
-    timer:sleep(100),
-    {ok, cowboy_req:reply(200, #{}, <<"I'm slow">>, Req), Opts};
-init(Req, extra_slow = Opts) ->
     timer:sleep(200),
-    {ok, cowboy_req:reply(200, #{}, <<"I'm extra_slow">>, Req), Opts}.
+    {ok, cowboy_req:reply(200, #{}, <<"I'm slow">>, Req), Opts};
+init(Req0, chunked = Opts) ->
+    Req = cowboy_req:stream_reply(200, Req0),
+    cowboy_req:stream_body("Hello\r\n", nofin, Req),
+    cowboy_req:stream_body("World\r\n", fin, Req),
+    {ok, Req, Opts};
+init(Req0, chunked_slow = Opts) ->
+    Req = cowboy_req:stream_reply(200, Req0),
+    cowboy_req:stream_body("Hello\r\n", nofin, Req),
+    timer:sleep(200),
+    cowboy_req:stream_body("World\r\n", fin, Req),
+    {ok, Req, Opts}.


### PR DESCRIPTION
When the client making a request hangs up (ex: client timeout), cowboy detects this and executes the `terminate` stream handler callback with 

```erlang
Reason = {socket_error, closed, 'The socket has been closed.'}
```

When the server reaches the `idle_timeout`, cowboy executes the `terminate` stream handler callback with

```erlang
Reason = {connection_error, timeout, 'Connection idle longer than configuration allows.'}
```

This PR emits a `[cowboy, request, stop]` event with an `error` instead of a `response` in that situation, since no response is ever sent to the client.