### PR TITLE
Wrap cowboy_metrics_h!

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,32 @@ A span event emitted at the beginning of a request.
 
 A span event emitted at the end of a request.
 
-* `measurements`: `#{duration => native_time()}`
-* `metadata`: `cowboy_metrics_h:metrics()`
+* `measurements`: `measurements()`
+* `metadata`: `metadata()`
 
 If the request is terminated early - by the client or by the server - before a response is sent, the metadata will also contain an `error`:
 
-* `metadata`: `cowboy_metrics_h:metrics()` + `#{error => cowboy_stream:reason()}`
+* `metadata`: `metadata()` + `#{error => cowboy_stream:reason()}`
 
 #### `[cowboy, request, exception]`
 
 A span event emitted if the request process exits.
 
-* `measurements`: `#{duration => native_time()}`
-* `metadata`: `cowboy_metrics_h:metrics()` + `#{kind => exit, reason => cowboy_stream:reason(), stacktrace => list()}`
+* `measurements`: `measurements()`
+* `metadata`: `metadata()` + `#{kind => exit, stacktrace => list()}`
 
 #### `[cowboy, request, early_error]`
 
 A single event emitted when Cowboy itself returns an `early_error` response before executing any handlers.
 
-* `measurements`: `#{system_time => erlang:system_time()}`
-* `metadata`: `cowboy_metrics_h:metrics()`
+* `measurements`: `#{system_time => erlang:system_time(), resp_body_length => non_neg_integer()}`
+* `metadata`: `metadata()` without `procs` or `informational`
+
+### Types
+
+* `metrics`: `duration`, `req_body_duration`, `resp_duration`, `req_body_length`, and `resp_body_length` from `cowboy_metrics_h:metrics()`
+* `metadata`: `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `reason`, `procs`, `informational`, and `ref` from `cowboy_metrics_h:metrics()`
+* `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/f673e191b30ab440440c924476bb03000fff52c6/src/cowboy_metrics_h.erl#L46)
 
 Note:
 

--- a/README.md
+++ b/README.md
@@ -32,39 +32,26 @@ A span event emitted at the beginning of a request.
 
 A span event emitted at the end of a request.
 
-* `measurements`: `#{duration => native_time}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), response => response()}`
+* `measurements`: `#{duration => native_time()}`
+* `metadata`: `cowboy_metrics_h:metrics()`
 
-If the request is streamed in chunks, the `resp_body` reported will be `nil`.
+If the request is terminated early - by the client or by the server - before a response is sent, the metadata will also contain an `error`:
 
-If the request is terminated early - by the client or by the server - before a response is sent, the metadata contains an `error` instead of a `response`,
-
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), error => early_termination_error()}`
+* `metadata`: `cowboy_metrics_h:metrics()` + `#{error => cowboy_stream:reason()}`
 
 #### `[cowboy, request, exception]`
 
 A span event emitted if the request process exits.
 
-* `measurements`: `#{duration => native_time}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), kind => exit, reason => any(), response => error_response()}`
+* `measurements`: `#{duration => native_time()}`
+* `metadata`: `cowboy_metrics_h:metrics()` + `#{kind => exit, reason => cowboy_stream:reason(), stacktrace => list()}`
 
 #### `[cowboy, request, early_error]`
 
 A single event emitted when Cowboy itself returns an `early_error` response before executing any handlers.
 
-* `measurements`: `#{duration => native_time}`
-* `metadata`: `#{stream_id => cowboy_stream:streamid(), reason => cowboy_stream:reason(), partial_req => cowboy_stream:partial_req()}`
-
-Additional types for reference:
-
-```erlang
-- type response() :: {response, cowboy:http_status(), cowboy:http_headers(), nil | cowboy_req:resp_body()}.
-
-- type error_response() :: {error_response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}.
-
-- type early_termination_error() :: {socket_error, closed | atom(), cowboy_stream:human_reason()}
-                                    | {connection_error, timeout, cowboy_stream:human_reason()}.
-```
+* `measurements`: `#{system_time => erlang:system_time()}`
+* `metadata`: `cowboy_metrics_h:metrics()`
 
 Note:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
 
 ### Types
 
-* `metrics`: `duration`, `req_body_duration` (if there is a request body), `resp_duration`, `req_body_length`, and `resp_body_length` from `cowboy_metrics_h:metrics()`
+* `metrics`: `duration`, `req_body_duration`, `resp_duration`, `req_body_length`, and `resp_body_length` from `cowboy_metrics_h:metrics()`
 * `metadata`: `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `reason`, `procs`, `informational`, and `ref` from `cowboy_metrics_h:metrics()`
 * `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/f673e191b30ab440440c924476bb03000fff52c6/src/cowboy_metrics_h.erl#L46)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
 
 ### Types
 
-* `metrics`: `duration`, `req_body_duration`, `resp_duration`, `req_body_length`, and `resp_body_length` from `cowboy_metrics_h:metrics()`
+* `metrics`: `duration`, `req_body_duration` (if there is a request body), `resp_duration`, `req_body_length`, and `resp_body_length` from `cowboy_metrics_h:metrics()`
 * `metadata`: `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `reason`, `procs`, `informational`, and `ref` from `cowboy_metrics_h:metrics()`
 * `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/f673e191b30ab440440c924476bb03000fff52c6/src/cowboy_metrics_h.erl#L46)
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
 
 ### Types
 
-* `metrics`: `duration`, `req_body_duration`, `resp_duration`, `req_body_length`, and `resp_body_length` from `cowboy_metrics_h:metrics()`
-* `metadata`: `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `reason`, `procs`, `informational`, and `ref` from `cowboy_metrics_h:metrics()`
-* `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/f673e191b30ab440440c924476bb03000fff52c6/src/cowboy_metrics_h.erl#L46)
+* `measurements()`:
+  * `duration :: req_start - req_end` see [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L75)
+  * `req_body_duration :: req_body_start - req_body_end` see [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L80)
+  * `resp_duration :: resp_start - resp_end` see [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L87)
+  * `req_body_length :: non_neg_integer()`
+  * `resp_body_length :: non_neg_integer()`
+* `metadata()`:
+  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `reason`, `procs`, `informational`, and `ref` from `cowboy_metrics_h:metrics()`
+* `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L46)
 
 Note:
 

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -61,7 +61,8 @@ measurements(Metrics) ->
         #{duration => duration(req_start, req_end, Metrics),
           req_body_duration => duration(req_body_start, req_body_end, Metrics),
           resp_duration => duration(resp_start, resp_end, Metrics)},
-    maps:merge(Measurements, Durations).
+    Durations1 = maps:filter(fun(_K, V) -> V =/= undefined end, Durations),
+    maps:merge(Measurements, Durations1).
 
 metadata(Metrics, Extra) ->
     Metadata = maps:with([pid, streamid, req, resp_headers, resp_status, reason, procs, informational, ref], Metrics),

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -61,8 +61,7 @@ measurements(Metrics) ->
         #{duration => duration(req_start, req_end, Metrics),
           req_body_duration => duration(req_body_start, req_body_end, Metrics),
           resp_duration => duration(resp_start, resp_end, Metrics)},
-    Durations1 = maps:filter(fun(_K, V) -> V =/= undefined end, Durations),
-    maps:merge(Measurements, Durations1).
+    maps:merge(Measurements, Durations).
 
 metadata(Metrics, Extra) ->
     Metadata = maps:with([pid, streamid, req, resp_headers, resp_status, reason, procs, informational, ref], Metrics),
@@ -72,6 +71,6 @@ duration(StartKey, EndKey, Metrics) ->
     duration(maps:get(StartKey, Metrics, undefined), maps:get(EndKey, Metrics, undefined)).
 
 duration(Start, End) when Start =:= undefined; End =:= undefined ->
-    undefined;
+    0;
 duration(Start, End) ->
     End - Start.

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -7,138 +7,51 @@
 -export([terminate/3]).
 -export([early_error/5]).
 
-% Request Flows:
-%
-% There are multiple ways a request flows through the stream handler callbacks.
-% All start with `init`, where we emit our span start event. In each flow, the location
-% where we emit the span stop event is designated with ^^. All events are based on the
-% Commands returned by cowboy in `info`, or data in `terminate`.
-%
-% successful_request     == init -> info(response) ^^ -> info(stop) -> terminate(normal)
-% failed_request         == init -> info(error_response) ^^ -> terminate(internal_error)
-% client_timeout_request == init -> terminate(socket_error) ^^
-% idle_timeout_request   == init -> terminate(connection_error) ^^
-% chunked_request        == init -> info(headers) -> info(data|nofin) -> info(data|fin) ^^ -> info(stop) -> terminate(normal)
-% chunk_timeout_request  == init -> info(headers) -> info(data|nofin) -> terminate(connection_error) ^^
-
-% Data that needs to be accumulated across handler callbacks
--record(state, {
-    next :: any(),
-
-    % Request info
-    streamid :: cowboy_stream:streamid(),
-    start_time :: integer(),
-
-    % Span stop tracking
-    emit :: undefined | done,
-
-    % Chunked response data
-    chunked_resp_status :: undefined | cowboy:http_status(),
-    chunked_resp_headers :: undefined | cowbo:http_headers()
-}).
-
-% Data that needs to be accumulated while we fold over Commands
--record(acc, {
-    error_response :: undefined | {error_response, cowboy:http_status(), cowboy:http_headers(), cowboy_req:resp_body()}
-}).
-
 init(StreamID, Req, Opts) ->
-    StartTime = erlang:monotonic_time(),
-    SystemTime = erlang:system_time(),
-    emit_start_event(StreamID, SystemTime, Req),
-    {Commands, Next} = cowboy_stream:init(StreamID, Req, Opts),
-    {Commands, #state{next=Next, streamid=StreamID, start_time=StartTime}}.
-
-info(StreamID, Info, State=#state{next=Next0}) ->
-    {Commands, Next} = cowboy_stream:info(StreamID, Info, Next0),
-    {Commands, fold(Commands, State#state{next=Next}, #acc{})}.
-
-data(StreamID, IsFin, Data, State=#state{next=Next0}) ->
-    {Commands, Next} = cowboy_stream:data(StreamID, IsFin, Data, Next0),
-    {Commands, State#state{next=Next}}.
-
-terminate(StreamID, Reason, #state{emit=done, next=Next}) ->
-    cowboy_stream:terminate(StreamID, Reason, Next);
-terminate(StreamID, {ErrorType, _, _} = Reason, #state{next=Next, start_time=StartTime})
-    when ErrorType == socket_error;
-         ErrorType == connection_error ->
-    emit_stop_error_event(StreamID, StartTime, Reason),
-    cowboy_stream:terminate(StreamID, Reason, Next);
-terminate(StreamID, Reason, #state{next=Next}) ->
-    cowboy_stream:terminate(StreamID, Reason, Next).
-
-early_error(StreamID, Reason, PartialReq, Resp0, Opts) ->
-    Resp = cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp0, Opts),
-    emit_early_error_event(StreamID, Reason, PartialReq, Resp),
-    Resp.
-
-%
-
-fold([], State, _Acc) ->
-    State;
-
-fold([{response, _, _, _} = Response | Tail],
-     #state{streamid=StreamID, start_time=StartTime} = State,
-     Acc) ->
-    emit_stop_event(StreamID, StartTime, Response),
-    fold(Tail, State#state{emit=done}, Acc);
-
-fold([{data, fin, _} | Tail],
-     #state{streamid=StreamID, start_time=StartTime, chunked_resp_status=RespStatus, chunked_resp_headers=RespHeaders} = State,
-     Acc) ->
-    emit_stop_event(StreamID, StartTime, {response, RespStatus, RespHeaders, nil}),
-    fold(Tail, State#state{emit=done, chunked_resp_status=undefined, chunked_resp_headers = undefined}, Acc);
-
-fold([{internal_error, {'EXIT', _, Reason}, _} | Tail],
-     #state{streamid=StreamID, start_time=StartTime} = State,
-     #acc{error_response=ErrorResponse}) ->
-    emit_exception_event(StreamID, StartTime, Reason, ErrorResponse),
-    fold(Tail, State#state{emit=done}, #acc{});
-
-fold([{headers, RespStatus, RespHeaders} | Tail], State, Acc) ->
-    fold(Tail, State#state{chunked_resp_status=RespStatus, chunked_resp_headers=RespHeaders}, Acc);
-
-fold([{error_response, _, _, _} = ErrorResponse | Tail], State, Acc) ->
-    fold(Tail, State, Acc#acc{error_response=ErrorResponse});
-
-fold([_ | Tail], State, Acc) ->
-    fold(Tail, State, Acc).
-
-emit_start_event(StreamID, SystemTime, Req) ->
     telemetry:execute(
         [cowboy, request, start],
-        #{system_time => SystemTime},
-        #{stream_id => StreamID, req => Req}
-    ).
+        #{system_time => erlang:system_time()},
+        #{streamid => StreamID, req => Req}),
+    cowboy_metrics_h:init(StreamID, Req, add_metrics_callback(Opts)).
 
-emit_stop_event(StreamID, StartTime, Response) ->
-    EndTime = erlang:monotonic_time(),
-    telemetry:execute(
-        [cowboy, request, stop],
-        #{duration => EndTime - StartTime},
-        #{stream_id => StreamID, response => Response}
-    ).
+info(StreamID, Info, State) ->
+    cowboy_metrics_h:info(StreamID, Info, State).
 
-emit_stop_error_event(StreamID, StartTime, Reason) ->
-    EndTime = erlang:monotonic_time(),
-    telemetry:execute(
-        [cowboy, request, stop],
-        #{duration => EndTime - StartTime},
-        #{stream_id => StreamID, error => Reason}
-    ).
+data(StreamID, IsFin, Data, State) ->
+    cowboy_metrics_h:data(StreamID, IsFin, Data, State).
 
-emit_exception_event(StreamID, StartTime, Reason, ErrorResponse) ->
-    EndTime = erlang:monotonic_time(),
+terminate(StreamID, Reason, State) ->
+    cowboy_metrics_h:terminate(StreamID, Reason, State).
+
+early_error(StreamID, Reason, PartialReq, Resp, Opts) ->
+    cowboy_metrics_h:early_error(StreamID, Reason, PartialReq, Resp, add_metrics_callback(Opts)).
+
+%
+
+add_metrics_callback(Opts) ->
+    maps:put(metrics_callback, fun metrics_callback/1, Opts).
+
+metrics_callback(#{reason := {internal_error, {'EXIT', _, {_, Stacktrace}}, _}, req_start := ReqStart, req_end := ReqEnd} = Metadata) ->
     telemetry:execute(
         [cowboy, request, exception],
-        #{duration => EndTime - StartTime},
-        #{stream_id => StreamID, kind => exit, reason => Reason, error_response => ErrorResponse}
-    ).
-
-emit_early_error_event(StreamID, Reason, PartialReq, Resp) ->
-    SystemTime = erlang:system_time(),
+        #{duration => ReqEnd - ReqStart},
+        maps:merge(Metadata, #{kind => exit, stacktrace => Stacktrace}));
+metrics_callback(#{reason := {ErrorType, _, _} = Reason, req_start := ReqStart, req_end := ReqEnd} = Metadata)
+    when ErrorType == socket_error;
+         ErrorType == connection_error ->
+    telemetry:execute(
+        [cowboy, request, stop],
+        #{duration => ReqEnd - ReqStart},
+        maps:merge(Metadata, #{error => Reason}));
+metrics_callback(#{req_start := ReqStart, req_end := ReqEnd} = Metadata) ->
+    telemetry:execute(
+        [cowboy, request, stop],
+        #{duration => ReqEnd - ReqStart},
+        Metadata);
+metrics_callback(#{early_error_time := _} = Metadata) ->
     telemetry:execute(
         [cowboy, request, early_error],
-        #{system_time => SystemTime},
-        #{stream_id => StreamID, reason => Reason, partial_req => PartialReq, response => Resp}
-    ).
+        #{system_time => erlang:system_time()},
+        Metadata);
+metrics_callback(_Metrics) ->
+    unexpected.

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -32,10 +32,11 @@ add_metrics_callback(Opts) ->
     maps:put(metrics_callback, fun metrics_callback/1, Opts).
 
 metrics_callback(#{early_error_time := Time} = Metrics) when is_number(Time) ->
+    {RespBodyLength, Metadata} = maps:take(resp_body_length, Metrics),
     telemetry:execute(
         [cowboy, request, early_error],
-        #{system_time => erlang:system_time()},
-        Metrics);
+        #{system_time => erlang:system_time(), resp_body_length => RespBodyLength},
+        Metadata);
 metrics_callback(#{reason := {internal_error, {'EXIT', _, {_, Stacktrace}}, _}} = Metrics) ->
     telemetry:execute(
         [cowboy, request, exception],

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -55,26 +55,21 @@ metrics_callback(Metrics) ->
         metadata(Metrics, #{})).
 
 measurements(Metrics) ->
-    Metadata = maps:with([req_body_length, resp_body_length], Metrics),
+    Measurements = maps:with([req_body_length, resp_body_length], Metrics),
     Durations =
         #{duration => duration(req_start, req_end, Metrics),
           req_body_duration => duration(req_body_start, req_body_end, Metrics),
           resp_duration => duration(resp_start, resp_end, Metrics)},
-    maps:merge(Metadata, Durations).
+    maps:merge(Measurements, Durations).
 
 metadata(Metrics, Extra) ->
     Metadata = maps:with([pid, streamid, req, resp_headers, resp_status, reason, procs, informational, ref], Metrics),
     maps:merge(Metadata, Extra).
 
-% Helpers
-
 duration(StartKey, EndKey, Metrics) ->
-    duration(get(StartKey, Metrics), get(EndKey, Metrics)).
+    duration(maps:get(StartKey, Metrics, undefined), maps:get(EndKey, Metrics, undefined)).
 
 duration(Start, End) when Start =:= undefined; End =:= undefined ->
     undefined;
 duration(Start, End) ->
     End - Start.
-
-get(Key, Map) ->
-   maps:get(Key, Map, undefined).

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -31,27 +31,57 @@ early_error(StreamID, Reason, PartialReq, Resp, Opts) ->
 add_metrics_callback(Opts) ->
     maps:put(metrics_callback, fun metrics_callback/1, Opts).
 
-metrics_callback(#{reason := {internal_error, {'EXIT', _, {_, Stacktrace}}, _}, req_start := ReqStart, req_end := ReqEnd} = Metadata) ->
+metrics_callback(#{early_error_time := Time} = Metrics) when is_number(Time) ->
+    telemetry:execute(
+        [cowboy, request, early_error],
+        #{system_time => erlang:system_time()},
+        Metrics);
+metrics_callback(#{reason := {internal_error, {'EXIT', _, {_, Stacktrace}}, _}} = Metrics) ->
     telemetry:execute(
         [cowboy, request, exception],
-        #{duration => ReqEnd - ReqStart},
-        maps:merge(Metadata, #{kind => exit, stacktrace => Stacktrace}));
-metrics_callback(#{reason := {ErrorType, _, _} = Reason, req_start := ReqStart, req_end := ReqEnd} = Metadata)
+        measurements(Metrics),
+        metadata(Metrics, #{kind => exit, stacktrace => Stacktrace}));
+metrics_callback(#{reason := {ErrorType, _, _} = Reason} = Metrics)
     when ErrorType == socket_error;
          ErrorType == connection_error ->
     telemetry:execute(
         [cowboy, request, stop],
-        #{duration => ReqEnd - ReqStart},
-        maps:merge(Metadata, #{error => Reason}));
-metrics_callback(#{req_start := ReqStart, req_end := ReqEnd} = Metadata) ->
+        measurements(Metrics),
+        metadata(Metrics, #{error => Reason}));
+metrics_callback(Metrics) ->
     telemetry:execute(
         [cowboy, request, stop],
-        #{duration => ReqEnd - ReqStart},
-        Metadata);
-metrics_callback(#{early_error_time := _} = Metadata) ->
-    telemetry:execute(
-        [cowboy, request, early_error],
-        #{system_time => erlang:system_time()},
-        Metadata);
-metrics_callback(_Metrics) ->
-    unexpected.
+        measurements(Metrics),
+        metadata(Metrics, #{})).
+
+measurements(Metrics) ->
+    #{duration => duration(req_start, req_end, Metrics),
+      req_body_duration => duration(req_body_start, req_body_end, Metrics),
+      req_body_length => get(req_body_length, Metrics),
+      resp_duration => duration(resp_start, resp_end, Metrics),
+      resp_body_length => get(resp_body_length, Metrics)}.
+
+metadata(Metrics, Extra) ->
+    maps:merge(Extra, #{
+      pid => get(pid, Metrics),
+      streamid => get(streamid, Metrics),
+      req => get(req, Metrics),
+      resp_headers => get(resp_headers, Metrics),
+      resp_status => get(resp_status, Metrics),
+      reason => get(reason, Metrics),
+      procs => get(procs, Metrics),
+      informational => get(informational, Metrics),
+      ref => get(ref, Metrics)}).
+
+% Helpers
+
+duration(StartKey, EndKey, Metrics) ->
+    duration(get(StartKey, Metrics), get(EndKey, Metrics)).
+
+duration(Start, End) when Start =:= undefined; End =:= undefined ->
+    undefined;
+duration(Start, End) ->
+    End - Start.
+
+get(Key, Map) ->
+   maps:get(Key, Map, undefined).

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -55,23 +55,16 @@ metrics_callback(Metrics) ->
         metadata(Metrics, #{})).
 
 measurements(Metrics) ->
-    #{duration => duration(req_start, req_end, Metrics),
-      req_body_duration => duration(req_body_start, req_body_end, Metrics),
-      req_body_length => get(req_body_length, Metrics),
-      resp_duration => duration(resp_start, resp_end, Metrics),
-      resp_body_length => get(resp_body_length, Metrics)}.
+    Metadata = maps:with([req_body_length, resp_body_length], Metrics),
+    Durations =
+        #{duration => duration(req_start, req_end, Metrics),
+          req_body_duration => duration(req_body_start, req_body_end, Metrics),
+          resp_duration => duration(resp_start, resp_end, Metrics)},
+    maps:merge(Metadata, Durations).
 
 metadata(Metrics, Extra) ->
-    maps:merge(Extra, #{
-      pid => get(pid, Metrics),
-      streamid => get(streamid, Metrics),
-      req => get(req, Metrics),
-      resp_headers => get(resp_headers, Metrics),
-      resp_status => get(resp_status, Metrics),
-      reason => get(reason, Metrics),
-      procs => get(procs, Metrics),
-      informational => get(informational, Metrics),
-      ref => get(ref, Metrics)}).
+    Metadata = maps:with([pid, streamid, req, resp_headers, resp_status, reason, procs, informational, ref], Metrics),
+    maps:merge(Metadata, Extra).
 
 % Helpers
 

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -249,7 +249,8 @@ bad_request(_Config) ->
         httpc:request(trace, {"http://localhost:8080/", []}, [], []),
     receive
         {[cowboy, request, early_error], EarlyErrorMeasurements, EarlyErrorMetadata} ->
-            ?assertEqual([system_time], maps:keys(EarlyErrorMeasurements)),
+            ?assert(is_map_key(system_time, EarlyErrorMeasurements)),
+            ?assert(is_map_key(resp_body_length, EarlyErrorMeasurements)),
             ?assert(is_map_key(streamid, EarlyErrorMetadata))
     after
         1000 -> ct:fail(bad_request_start_event)

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -57,8 +57,21 @@ successful_request(_Config) ->
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
-            ?assertEqual([duration], maps:keys(StopMeasurements)),
-            ?assert(is_map_key(streamid, StopMetadata))
+            ?assert(is_map_key(duration, StopMeasurements)),
+            ?assert(is_map_key(req_body_duration, StopMeasurements)),
+            ?assert(is_map_key(req_body_length, StopMeasurements)),
+            ?assert(is_map_key(resp_duration, StopMeasurements)),
+            ?assert(is_map_key(resp_body_length, StopMeasurements)),
+            %
+            ?assert(is_map_key(streamid, StopMetadata)),
+            ?assert(is_map_key(req, StopMetadata)),
+            ?assert(is_map_key(ref, StopMetadata)),
+            ?assert(is_map_key(procs, StopMetadata)),
+            ?assert(is_map_key(reason, StopMetadata)),
+            ?assert(is_map_key(pid, StopMetadata)),
+            ?assert(is_map_key(informational, StopMetadata)),
+            ?assert(is_map_key(resp_headers, StopMetadata)),
+            ?assert(is_map_key(resp_status, StopMetadata))
     after
         1000 -> ct:fail(successful_request_stop_event)
     end,
@@ -87,7 +100,7 @@ chunked_request(_Config) ->
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
-            ?assertEqual([duration], maps:keys(StopMeasurements)),
+            ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata))
     after
         1000 -> ct:fail(chunked_request_stop_event)
@@ -117,7 +130,7 @@ failed_request(_Config) ->
     end,
     receive
         {[cowboy, request, exception], ExceptionMeasurements, ExceptionMetadata} ->
-            ?assertEqual([duration], maps:keys(ExceptionMeasurements)),
+            ?assert(is_map_key(duration, ExceptionMeasurements)),
             ?assert(is_map_key(streamid, ExceptionMetadata)),
             ?assert(is_map_key(kind, ExceptionMetadata)),
             ?assert(is_map_key(reason, ExceptionMetadata)),
@@ -150,7 +163,7 @@ client_timeout_request(_Config) ->
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
-            ?assertEqual([duration], maps:keys(StopMeasurements)),
+            ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata)),
             ?assert(is_map_key(error, StopMetadata))
     after
@@ -181,7 +194,7 @@ idle_timeout_request(_Config) ->
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
-            ?assertEqual([duration], maps:keys(StopMeasurements)),
+            ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata)),
             ?assert(is_map_key(error, StopMetadata))
     after
@@ -211,7 +224,7 @@ chunk_timeout_request(_Config) ->
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
-            ?assertEqual([duration], maps:keys(StopMeasurements)),
+            ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata)),
             ?assert(is_map_key(error, StopMetadata))
     after

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -51,14 +51,14 @@ successful_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, streamid], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(successful_request_start_event)
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assertEqual([duration], maps:keys(StopMeasurements)),
-            ?assertEqual([response, stream_id], maps:keys(StopMetadata))
+            ?assert(is_map_key(streamid, StopMetadata))
     after
         1000 -> ct:fail(successful_request_stop_event)
     end,
@@ -81,14 +81,14 @@ chunked_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, streamid], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(chunked_request_start_event)
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assertEqual([duration], maps:keys(StopMeasurements)),
-            ?assertEqual([response, stream_id], maps:keys(StopMetadata))
+            ?assert(is_map_key(streamid, StopMetadata))
     after
         1000 -> ct:fail(chunked_request_stop_event)
     end,
@@ -111,14 +111,17 @@ failed_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, streamid], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(failed_request_start_event)
     end,
     receive
         {[cowboy, request, exception], ExceptionMeasurements, ExceptionMetadata} ->
             ?assertEqual([duration], maps:keys(ExceptionMeasurements)),
-            ?assertEqual([error_response, kind, reason, stream_id], maps:keys(ExceptionMetadata))
+            ?assert(is_map_key(streamid, ExceptionMetadata)),
+            ?assert(is_map_key(kind, ExceptionMetadata)),
+            ?assert(is_map_key(reason, ExceptionMetadata)),
+            ?assert(is_map_key(stacktrace, ExceptionMetadata))
     after
         1000 -> ct:fail(failed_request_exception_event)
     end,
@@ -141,14 +144,15 @@ client_timeout_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, streamid], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(client_timeout_request_start_event)
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assertEqual([duration], maps:keys(StopMeasurements)),
-            ?assertEqual([error, stream_id], maps:keys(StopMetadata))
+            ?assert(is_map_key(streamid, StopMetadata)),
+            ?assert(is_map_key(error, StopMetadata))
     after
         1000 -> ct:fail(client_timeout_request_stop_event)
     end,
@@ -171,14 +175,15 @@ idle_timeout_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, streamid], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(idle_timeout_request_start_event)
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assertEqual([duration], maps:keys(StopMeasurements)),
-            ?assertEqual([error, stream_id], maps:keys(StopMetadata))
+            ?assert(is_map_key(streamid, StopMetadata)),
+            ?assert(is_map_key(error, StopMetadata))
     after
         1000 -> ct:fail(idle_timeout_request_stop_event)
     end,
@@ -200,14 +205,15 @@ chunk_timeout_request(_Config) ->
     receive
         {[cowboy, request, start], StartMeasurements, StartMetadata} ->
             ?assertEqual([system_time], maps:keys(StartMeasurements)),
-            ?assertEqual([req, stream_id], maps:keys(StartMetadata))
+            ?assertEqual([req, streamid], maps:keys(StartMetadata))
     after
         1000 -> ct:fail(chunk_timeout_request_start_event)
     end,
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assertEqual([duration], maps:keys(StopMeasurements)),
-            ?assertEqual([error, stream_id], maps:keys(StopMetadata))
+            ?assert(is_map_key(streamid, StopMetadata)),
+            ?assert(is_map_key(error, StopMetadata))
     after
         1000 -> ct:fail(chunk_timeout_request_stop_event)
     end,
@@ -231,7 +237,7 @@ bad_request(_Config) ->
     receive
         {[cowboy, request, early_error], EarlyErrorMeasurements, EarlyErrorMetadata} ->
             ?assertEqual([system_time], maps:keys(EarlyErrorMeasurements)),
-            ?assertEqual([partial_req,reason,response,stream_id], maps:keys(EarlyErrorMetadata))
+            ?assert(is_map_key(streamid, EarlyErrorMetadata))
     after
         1000 -> ct:fail(bad_request_start_event)
     end,

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -58,7 +58,7 @@ successful_request(_Config) ->
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assert(is_map_key(duration, StopMeasurements)),
-            ?assert(not is_map_key(req_body_duration, StopMeasurements)), % GET request, no request body
+            ?assert(is_map_key(req_body_duration, StopMeasurements)),
             ?assert(is_map_key(req_body_length, StopMeasurements)),
             ?assert(is_map_key(resp_duration, StopMeasurements)),
             ?assert(is_map_key(resp_body_length, StopMeasurements)),

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -58,7 +58,7 @@ successful_request(_Config) ->
     receive
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assert(is_map_key(duration, StopMeasurements)),
-            ?assert(is_map_key(req_body_duration, StopMeasurements)),
+            ?assert(not is_map_key(req_body_duration, StopMeasurements)), % GET request, no request body
             ?assert(is_map_key(req_body_length, StopMeasurements)),
             ?assert(is_map_key(resp_duration, StopMeasurements)),
             ?assert(is_map_key(resp_body_length, StopMeasurements)),


### PR DESCRIPTION
After thinking through the comments from @essen in #5, I thought I'd try actually re-using `cowboy_metrics_h`... This was an experiment but the result is pretty interesting.

This PR re-works the entire handler by:

1) Emitting a `start` span event immediately in `init`
2) Delegating _all_ the stream handler callbacks to `cowboy_metrics_h`, inserting a `metrics_callback`
3) Emitting all the `stop` events based the `Metrics` provided in `metrics_callback`

The event `metadata` change, but we gain a ton of useful information about the request:
* https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L46

@josevalim @arkgil 