### PR TITLE
Improve performance of event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
   * `req_body_length :: non_neg_integer()`
   * `resp_body_length :: non_neg_integer()`
 * `metadata()`:
-  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `reason`, `procs`, `informational`, and `ref` from `cowboy_metrics_h:metrics()`
+  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status` and `ref` from `cowboy_metrics_h:metrics()`
 * `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L46)
 
 Note:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
   * `req_body_length :: non_neg_integer()`
   * `resp_body_length :: non_neg_integer()`
 * `metadata()`:
-  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status` and `ref` from `cowboy_metrics_h:metrics()`
+  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, and `ref` from `cowboy_metrics_h:metrics()`
 * `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L46)
 
 Note:

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -66,10 +66,7 @@ successful_request(_Config) ->
             ?assert(is_map_key(streamid, StopMetadata)),
             ?assert(is_map_key(req, StopMetadata)),
             ?assert(is_map_key(ref, StopMetadata)),
-            ?assert(is_map_key(procs, StopMetadata)),
-            ?assert(is_map_key(reason, StopMetadata)),
             ?assert(is_map_key(pid, StopMetadata)),
-            ?assert(is_map_key(informational, StopMetadata)),
             ?assert(is_map_key(resp_headers, StopMetadata)),
             ?assert(is_map_key(resp_status, StopMetadata))
     after


### PR DESCRIPTION
Define map keys at compilation time to reduce
allocations and rely more on pattern matching.