### PR TITLE
Move rebar3_hex to project_plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.
 {deps, [
     {telemetry, "~> 0.4"},
     {cowboy, "~> 2.7"}


### PR DESCRIPTION
This PR moves `rebar3_hex` to `project_plugins`. If rebar3_hex is in `plugins` vs `project_plugins` then rebar3_hex and all of its dependencies will be downloaded and compiled by users of this library. 