### PR TITLE
Add user_data to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A single event emitted when Cowboy itself returns an `early_error` response befo
   * `req_body_length :: non_neg_integer()`
   * `resp_body_length :: non_neg_integer()`
 * `metadata()`:
-  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, and `ref` from `cowboy_metrics_h:metrics()`
+  * `pid`, `streamid`, `req`, `resp_headers`, `resp_status`, `ref` and `user_data` from `cowboy_metrics_h:metrics()`
 * `cowboy_metrics_h:metrics()`: Defined in [`cowboy_metrics_h`](https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl#L46)
 
 Note:

--- a/src/cowboy_telemetry_h.erl
+++ b/src/cowboy_telemetry_h.erl
@@ -73,7 +73,8 @@ metadata(Metrics) ->
         req := Req,
         resp_headers := RespHeaders,
         resp_status := RespStatus,
-        ref := Ref
+        ref := Ref,
+        user_data := UserData
     } = Metrics,
 
     #{
@@ -82,7 +83,8 @@ metadata(Metrics) ->
         req => Req,
         resp_headers => RespHeaders,
         resp_status => RespStatus,
-        ref => Ref
+        ref => Ref,
+        user_data => UserData
     }.
 
 duration(StartKey, EndKey, Metrics) ->

--- a/test/cowboy_telemetry_h_SUITE.erl
+++ b/test/cowboy_telemetry_h_SUITE.erl
@@ -68,7 +68,8 @@ successful_request(_Config) ->
             ?assert(is_map_key(ref, StopMetadata)),
             ?assert(is_map_key(pid, StopMetadata)),
             ?assert(is_map_key(resp_headers, StopMetadata)),
-            ?assert(is_map_key(resp_status, StopMetadata))
+            ?assert(is_map_key(resp_status, StopMetadata)),
+            ?assert(is_map_key(user_data, StopMetadata))
     after
         1000 -> ct:fail(successful_request_stop_event)
     end,
@@ -131,7 +132,8 @@ failed_request(_Config) ->
             ?assert(is_map_key(streamid, ExceptionMetadata)),
             ?assert(is_map_key(kind, ExceptionMetadata)),
             ?assert(is_map_key(reason, ExceptionMetadata)),
-            ?assert(is_map_key(stacktrace, ExceptionMetadata))
+            ?assert(is_map_key(stacktrace, ExceptionMetadata)),
+            ?assert(is_map_key(user_data, ExceptionMetadata))
     after
         1000 -> ct:fail(failed_request_exception_event)
     end,
@@ -162,7 +164,8 @@ client_timeout_request(_Config) ->
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata)),
-            ?assert(is_map_key(error, StopMetadata))
+            ?assert(is_map_key(error, StopMetadata)),
+            ?assert(is_map_key(user_data, StopMetadata))
     after
         1000 -> ct:fail(client_timeout_request_stop_event)
     end,
@@ -193,7 +196,8 @@ idle_timeout_request(_Config) ->
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata)),
-            ?assert(is_map_key(error, StopMetadata))
+            ?assert(is_map_key(error, StopMetadata)),
+            ?assert(is_map_key(user_data, StopMetadata))
     after
         1000 -> ct:fail(idle_timeout_request_stop_event)
     end,
@@ -223,7 +227,8 @@ chunk_timeout_request(_Config) ->
         {[cowboy, request, stop], StopMeasurements, StopMetadata} ->
             ?assert(is_map_key(duration, StopMeasurements)),
             ?assert(is_map_key(streamid, StopMetadata)),
-            ?assert(is_map_key(error, StopMetadata))
+            ?assert(is_map_key(error, StopMetadata)),
+            ?assert(is_map_key(user_data, StopMetadata))
     after
         1000 -> ct:fail(chunk_timeout_request_stop_event)
     end,


### PR DESCRIPTION
Metrics generated by `cowboy_metrics_h` conveniently hold a `user_data` map which allows developers to include arbitrary information in the events from upstream handlers.

As per [cowboy's docs](https://ninenines.eu/docs/en/cowboy/2.9/manual/cowboy_metrics_h/):
> This can be used for example to add the handler module which was selected by the router